### PR TITLE
refactor: update API calls to directly use `NEXT_PUBLIC_API_URL` and …

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,15 +34,6 @@ const nextConfig = {
     ],
   },
   skipTrailingSlashRedirect: true,
-  async rewrites() {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
-    return [
-      {
-        source: '/api/bx/:path*',
-        destination: `${apiUrl}/bx/:path*`,
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,16 +1,14 @@
-// All API calls go through Next.js rewrites (see next.config.mjs)
-// /api/bx/* → gx-backend /bx/*
-// This avoids CORS issues and keeps the backend URL hidden from the client.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
 
 export function bxApi(path: string, init?: RequestInit) {
-  return fetch(`/api/bx${path}`, {
+  return fetch(`${API_BASE}/bx${path}`, {
     credentials: "include",
     ...init,
   });
 }
 
 export function gxApi(path: string, init?: RequestInit) {
-  return fetch(`/api${path}`, {
+  return fetch(`${API_BASE}${path}`, {
     credentials: "include",
     ...init,
   });


### PR DESCRIPTION
…remove Next.js rewrites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint configuration to use centralized environment variables for improved maintainability and flexibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->