### PR TITLE
fix: Remove duplicate nav from settings page and add Settings to AppN…

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,47 +1,17 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useCallback } from "react";
 import {
   C,
   T,
-  ROLES,
   type BuilderProfile,
   type BxApiKey,
   normalizeUser,
 } from "@/types";
-import { bxApi, clearToken } from "@/lib/api";
+import { bxApi } from "@/lib/api";
 import { useLoginDialog } from "@/context/LoginDialogContext";
-import { useResponsive } from "@/hooks/useMediaQuery";
-import BuiltLogo from "@/components/BuiltLogo";
 
 // ---- Inline Components ----
-
-function Av({ initials, size = 32, role, src }: { initials: string; size?: number; role?: string; src?: string }) {
-  const r = role ? ROLES[role] : undefined;
-  if (src && src.startsWith("http")) {
-    return (
-      <img src={src} alt={initials} style={{
-        width: size, height: size, borderRadius: size,
-        border: `1px solid ${C.borderLight}`, flexShrink: 0, objectFit: "cover",
-      }} />
-    );
-  }
-  return (
-    <div style={{
-      width: size, height: size, borderRadius: size,
-      background: r?.bg || C.accentSoft,
-      color: r?.color || C.textSec,
-      display: "flex", alignItems: "center", justifyContent: "center",
-      fontSize: Math.round(size * 0.36), fontWeight: 650,
-      fontFamily: "var(--sans)", letterSpacing: "0.01em",
-      border: `1px solid ${C.borderLight}`,
-      flexShrink: 0,
-    }}>
-      {initials}
-    </div>
-  );
-}
 
 function timeAgo(dateStr: string): string {
   const now = Date.now();
@@ -66,10 +36,7 @@ function formatDate(dateStr: string): string {
 // ---- Main Page ----
 
 export default function SettingsPage() {
-  const router = useRouter();
   const { openLoginDialog } = useLoginDialog();
-  const { isMobile } = useResponsive();
-  const profileMenuRef = useRef<HTMLDivElement>(null);
 
   // Auth + User
   const [user, setUser] = useState<BuilderProfile | null>(null);
@@ -93,9 +60,6 @@ export default function SettingsPage() {
   // Revoke flow
   const [revokeTarget, setRevokeTarget] = useState<BxApiKey | null>(null);
   const [revoking, setRevoking] = useState(false);
-
-  // Navbar
-  const [showProfileMenu, setShowProfileMenu] = useState(false);
 
   // OpenClaw guide
   const [guideExpanded, setGuideExpanded] = useState(false);
@@ -133,24 +97,7 @@ export default function SettingsPage() {
       .finally(() => setUserLoading(false));
   }, [loadKeys, openLoginDialog]);
 
-  // Click-outside for profile menu
-  useEffect(() => {
-    const h = (e: MouseEvent) => {
-      if (profileMenuRef.current && !profileMenuRef.current.contains(e.target as Node)) {
-        setShowProfileMenu(false);
-      }
-    };
-    document.addEventListener("mousedown", h);
-    return () => document.removeEventListener("mousedown", h);
-  }, []);
-
   // ---- Handlers ----
-
-  const handleSignOut = () => {
-    clearToken();
-    bxApi("/logout", { method: "POST" }).catch(() => {});
-    router.push("/");
-  };
 
   const handleCreateKey = async () => {
     const name = newKeyName.trim();
@@ -217,70 +164,6 @@ export default function SettingsPage() {
 
   return (
     <div style={{ minHeight: "100vh", background: C.bg, fontFamily: "var(--sans)" }}>
-      {/* Nav */}
-      <nav className="responsive-nav" style={{
-        position: "sticky", top: 0, zIndex: 50,
-        background: "rgba(248,247,244,0.9)", backdropFilter: "blur(16px)",
-        borderBottom: `1px solid ${C.border}`, padding: "0 32px",
-      }}>
-        <div style={{
-          maxWidth: 960, margin: "0 auto",
-          display: "flex", alignItems: "center", justifyContent: "space-between", height: 65,
-        }}>
-          <div style={{ display: "flex", alignItems: "center", gap: isMobile ? 0 : 20 }}>
-            <BuiltLogo height={40} onClick={() => router.push("/")} />
-            {!isMobile && (
-              <>
-                <span style={{ color: C.textMute, fontSize: T.bodySm }}>/</span>
-                <span style={{ fontSize: T.body, fontWeight: 600, color: C.text, fontFamily: "var(--sans)" }}>Settings</span>
-              </>
-            )}
-          </div>
-          {userLoading ? (
-            <div style={{ width: 32, height: 32, borderRadius: 32 }} className="skeleton" />
-          ) : user ? (
-            <div ref={profileMenuRef} style={{ position: "relative" }}>
-              <button onClick={() => setShowProfileMenu(v => !v)} style={{ background: "none", border: "none", cursor: "pointer", padding: 0, display: "flex", alignItems: "center", gap: 6 }}>
-                <Av initials={user.avatar} size={32} role={user.role} src={user.avatarUrl} />
-                <span style={{ fontSize: T.label, color: C.textSec, fontWeight: 500, fontFamily: "var(--sans)" }}>{user.name.split(" ")[0]}</span>
-                <span style={{ fontSize: 9, color: C.textMute, transform: showProfileMenu ? "rotate(180deg)" : "none", transition: "transform 0.2s" }}>{"\u25BC"}</span>
-              </button>
-              {showProfileMenu && (
-                <div style={{
-                  position: "absolute", top: "calc(100% + 8px)", right: 0,
-                  background: C.surface, border: `1px solid ${C.border}`, borderRadius: 12,
-                  boxShadow: "0 8px 24px rgba(0,0,0,0.1)", minWidth: 180, overflow: "hidden", zIndex: 100,
-                }}>
-                  <button onClick={() => { setShowProfileMenu(false); router.push("/my-projects"); }} style={{
-                    width: "100%", padding: "12px 16px", border: "none", background: "none",
-                    cursor: "pointer", fontSize: T.bodySm, fontWeight: 500, color: C.text,
-                    fontFamily: "var(--sans)", textAlign: "left", display: "flex", alignItems: "center", gap: 8,
-                    transition: "background 0.1s",
-                  }}
-                  onMouseEnter={e => e.currentTarget.style.background = C.accentSoft}
-                  onMouseLeave={e => e.currentTarget.style.background = "none"}
-                  >
-                    <span style={{ fontSize: T.body }}>{"\u{1F4E6}"}</span> My Projects
-                  </button>
-                  <div style={{ height: 1, background: C.borderLight }} />
-                  <button onClick={handleSignOut} style={{
-                    width: "100%", padding: "12px 16px", border: "none", background: "none",
-                    cursor: "pointer", fontSize: T.bodySm, fontWeight: 500, color: "#B91C1C",
-                    fontFamily: "var(--sans)", textAlign: "left", display: "flex", alignItems: "center", gap: 8,
-                    transition: "background 0.1s",
-                  }}
-                  onMouseEnter={e => e.currentTarget.style.background = "#FEF2F2"}
-                  onMouseLeave={e => e.currentTarget.style.background = "none"}
-                  >
-                    <span style={{ fontSize: T.body }}>{"\u{1F6AA}"}</span> Sign out
-                  </button>
-                </div>
-              )}
-            </div>
-          ) : null}
-        </div>
-      </nav>
-
       <main className="responsive-main" style={{ maxWidth: 960, margin: "0 auto", padding: "32px 32px 100px" }}>
         {/* Page header */}
         <div className="fade-up" style={{ marginBottom: 36 }}>

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -178,6 +178,10 @@ export default function AppNav() {
                           <span style={{ fontSize: T.body }}>{"\u{1F4E6}"}</span> My Projects
                         </button>
                         <div style={{ height: 1, background: C.borderLight }} />
+                        <button onClick={() => { setShowProfileMenu(false); router.push("/settings"); }} style={{ width: "100%", padding: "12px 16px", border: "none", background: "none", cursor: "pointer", fontSize: T.bodySm, fontWeight: 500, color: C.text, fontFamily: "var(--sans)", textAlign: "left", display: "flex", alignItems: "center", gap: 8 }}>
+                          <span style={{ fontSize: T.body }}>{"\u2699\uFE0F"}</span> Settings
+                        </button>
+                        <div style={{ height: 1, background: C.borderLight }} />
                         <button onClick={() => { setShowProfileMenu(false); handleSignOut(); }} style={{ width: "100%", padding: "12px 16px", border: "none", background: "none", cursor: "pointer", fontSize: T.bodySm, fontWeight: 500, color: "#B91C1C", fontFamily: "var(--sans)", textAlign: "left", display: "flex", alignItems: "center", gap: 8 }}>
                           <span style={{ fontSize: T.body }}>{"\u{1F6AA}"}</span> Sign out
                         </button>
@@ -239,6 +243,18 @@ export default function AppNav() {
                         onMouseLeave={e => e.currentTarget.style.background = "none"}
                         >
                           <span style={{ fontSize: T.body }}>{"\u{1F4E6}"}</span> My Projects
+                        </button>
+                        <div style={{ height: 1, background: C.borderLight }} />
+                        <button onClick={() => { setShowProfileMenu(false); router.push("/settings"); }} style={{
+                          width: "100%", padding: "12px 16px", border: "none", background: "none",
+                          cursor: "pointer", fontSize: T.bodySm, fontWeight: 500, color: C.text,
+                          fontFamily: "var(--sans)", textAlign: "left", display: "flex", alignItems: "center", gap: 8,
+                          transition: "background 0.1s",
+                        }}
+                        onMouseEnter={e => e.currentTarget.style.background = C.accentSoft}
+                        onMouseLeave={e => e.currentTarget.style.background = "none"}
+                        >
+                          <span style={{ fontSize: T.body }}>{"\u2699\uFE0F"}</span> Settings
                         </button>
                         <div style={{ height: 1, background: C.borderLight }} />
                         <button onClick={handleSignOut} style={{


### PR DESCRIPTION
…av dropdown

The settings page had its own inline nav causing a double navigation bar. Removed it in favor of the global AppNav, and added a Settings link to the profile dropdown menu (both mobile and desktop).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Settings menu option to the user profile menu for easy access to account settings.

* **Refactor**
  * Streamlined the Settings page interface, focusing on API Keys management with simplified layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->