### PR TITLE
fix: remove unsupported buildProcess/isDraft fields from POST body

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -383,8 +383,8 @@ function HomePage() {
           category: "AI",
           stack: submitData.stack,
           url: submitData.url?.trim() || undefined,
-          buildProcess: submitData.buildProcess || undefined,
-          isDraft: savingAsDraft || undefined,
+          // buildProcess and isDraft are collected in the form but not sent yet
+          // (backend needs to be updated per BACKEND_CHANGES.md to accept these fields)
           creators: submitData.team.filter(c => c.role === 'creator').map(c => c._id),
           collabs: submitData.team.filter(c => c.role === 'collaborator').map(c => c._id),
         }),


### PR DESCRIPTION
The backend at backend.growthx.club hasn't been updated to accept buildProcess and isDraft fields yet, causing a 400 "buildProcess is not allowed" error on project submission. Strip these from the request body until the backend changes in BACKEND_CHANGES.md are implemented.

https://claude.ai/code/session_01D2JK5ywJbgRJjVRnTxD7F8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project creation payload to stop transmitting buildProcess and isDraft fields to the backend. These fields remain collected in the form pending backend implementation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->