### PR TITLE
refactor: single UpvoteButton component for all contexts

### DIFF
--- a/components/ProjectDetailClient.tsx
+++ b/components/ProjectDetailClient.tsx
@@ -25,6 +25,7 @@ import { useResponsive } from "@/hooks/useMediaQuery";
 import RichTextDisplay from "@/components/RichTextDisplay";
 import MediaGallery from "@/components/MediaGallery";
 import ProjectIcon from "@/components/ProjectIcon";
+import UpvoteButton from "@/components/UpvoteButton";
 
 function timeAgo(dateStr: string): string {
   const date = new Date(dateStr);
@@ -432,6 +433,22 @@ export default function ProjectDetailPage() {
   };
   handleVoteRef.current = handleVote;
 
+  // Wrapper for UpvoteButton component
+  const onVoteForButton = async (): Promise<{ voted: boolean; weighted: number; raw: number } | null> => {
+    const res = await bxApi("/votes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId: project?._id || project?.id || params.id }),
+    });
+    if (!res.ok) return null;
+    const result = await res.json();
+    const w = result.weighted ?? result.weighted_votes ?? result.weightedVotes ?? 0;
+    const r = result.raw ?? result.raw_votes ?? result.rawVotes ?? 0;
+    setHasVoted(result.voted);
+    setProject((prev) => prev ? { ...prev, weighted: w, raw: r } : prev);
+    return { voted: result.voted, weighted: w, raw: r };
+  };
+
   const handlePostComment = async () => {
     if (!comment.trim() || postingComment) return;
     if (!user) {
@@ -700,26 +717,14 @@ export default function ProjectDetailPage() {
               </div>
             </div>
             <div ref={voteBtnRef} style={{ flexShrink: 0, display: isMobile ? "none" : "flex", gap: 10, alignItems: "center" }}>
-              <button data-vote-detail onClick={handleVote}
-              className={voteAnim ? "vote-pop-active" : ""}
-              style={{
-                display: "flex", alignItems: "center", gap: 8,
-                padding: hasVoted ? "12px 28px" : "10px 22px", borderRadius: hasVoted ? 12 : 24,
-                border: hasVoted ? `1.5px solid ${C.accent}` : `1.5px solid ${C.border}`,
-                background: hasVoted ? C.accent : "transparent",
-                cursor: "pointer", fontSize: hasVoted ? T.bodyLg : T.body, fontWeight: hasVoted ? 700 : 600,
-                fontFamily: "var(--sans)", color: hasVoted ? C.accentFg : C.text,
-                transition: "all 0.25s",
-                position: "relative", overflow: "visible",
-              }}
-              onMouseEnter={e => { e.currentTarget.style.opacity = "0.85"; }}
-              onMouseLeave={e => { e.currentTarget.style.opacity = "1"; }}
-              >
-                <svg width={hasVoted ? 20 : 16} height={hasVoted ? 20 : 16} viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
-                  <path d="M10.6 7.4a1.6 1.6 0 0 1 2.8 0l6.4 10.8A1.6 1.6 0 0 1 18.4 20H5.6a1.6 1.6 0 0 1-1.4-2.4L10.6 7.4Z" fill={hasVoted ? "currentColor" : "none"} stroke="currentColor" strokeWidth={hasVoted ? 0 : 2} />
-                </svg>
-                <span style={{ lineHeight: 1 }}>{hasVoted ? "Voted" : ""} {hasVoted ? "\u00B7 " : ""}{p.weighted.toLocaleString()}</span>
-              </button>
+              <UpvoteButton
+                projectId={p._id || p.id}
+                weighted={p.weighted}
+                hasVoted={hasVoted}
+                onVote={user ? onVoteForButton : undefined}
+                onUnauthClick={() => openLoginDialog(() => { reloadUser(); reloadComments(); })}
+                size="detail"
+              />
               {p.url && (
                 <a href={p.url} target="_blank" rel="noopener noreferrer" style={{
                   padding: "8px 16px", borderRadius: 8,
@@ -1156,25 +1161,15 @@ export default function ProjectDetailPage() {
             display: "flex", gap: 10,
             boxShadow: "0 -2px 12px rgba(0,0,0,0.06)",
           }}>
-            <button
-              data-vote-float
-              onClick={handleVote}
-              className={voteAnim ? "vote-pop-active" : ""}
-              style={{
-                flex: 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 8,
-                padding: "13px 20px", borderRadius: hasVoted ? 12 : 24,
-                border: hasVoted ? "none" : `1.5px solid ${C.border}`,
-                background: hasVoted ? C.accent : "transparent", cursor: "pointer",
-                fontSize: T.body, fontWeight: hasVoted ? 700 : 600, fontFamily: "var(--sans)",
-                color: hasVoted ? C.accentFg : C.text, transition: "all 0.25s",
-                position: "relative", overflow: "visible",
-              }}
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
-                <path d="M10.6 7.4a1.6 1.6 0 0 1 2.8 0l6.4 10.8A1.6 1.6 0 0 1 18.4 20H5.6a1.6 1.6 0 0 1-1.4-2.4L10.6 7.4Z" fill={hasVoted ? "currentColor" : "none"} stroke="currentColor" strokeWidth={hasVoted ? 0 : 2} />
-              </svg>
-              <span style={{ lineHeight: 1 }}>{hasVoted ? "Voted" : ""} {hasVoted ? "\u00B7 " : ""}{p.weighted.toLocaleString()}</span>
-            </button>
+            <UpvoteButton
+              projectId={p._id || p.id}
+              weighted={p.weighted}
+              hasVoted={hasVoted}
+              onVote={user ? onVoteForButton : undefined}
+              onUnauthClick={() => openLoginDialog(() => { reloadUser(); reloadComments(); })}
+              size="float"
+              style={{ flex: 1 }}
+            />
             {p.url && (
               <a href={p.url} target="_blank" rel="noopener noreferrer" style={{
                 padding: "13px 20px", borderRadius: 12,

--- a/components/UpvoteButton.tsx
+++ b/components/UpvoteButton.tsx
@@ -14,7 +14,9 @@ interface UpvoteButtonProps {
   hasVoted: boolean;
   onVote?: (projectId: string | number) => Promise<{ voted: boolean; weighted: number; raw: number } | null>;
   onUnauthClick?: () => void;
-  size?: "default" | "large";
+  size?: "default" | "large" | "detail" | "float";
+  className?: string;
+  style?: React.CSSProperties;
 }
 
 export default function UpvoteButton({
@@ -24,14 +26,14 @@ export default function UpvoteButton({
   onVote,
   onUnauthClick,
   size = "default",
+  className,
+  style: extraStyle,
 }: UpvoteButtonProps) {
   const [voted, setVoted] = useState(initialVoted);
   const [weighted, setWeighted] = useState(initialWeighted);
   const [loading, setLoading] = useState(false);
   const [popActive, setPopActive] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
-
-  const isLarge = size === "large";
 
   const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -89,42 +91,76 @@ export default function UpvoteButton({
     }
   };
 
-  const iconSize = isLarge ? 16 : 12;
+  // Size-specific styles
+  const sizeConfig = {
+    default: {
+      iconSize: 12,
+      padding: voted ? "4px 10px" : "6px 14px",
+      borderRadius: voted ? 8 : 20,
+      fontSize: T.bodySm,
+      fontWeight: 650,
+      showLabel: false,
+    },
+    large: {
+      iconSize: 16,
+      padding: "10px 18px",
+      borderRadius: 10,
+      fontSize: T.subtitle,
+      fontWeight: 650,
+      showLabel: false,
+    },
+    detail: {
+      iconSize: voted ? 20 : 16,
+      padding: voted ? "12px 28px" : "10px 22px",
+      borderRadius: voted ? 12 : 24,
+      fontSize: voted ? T.bodyLg : T.body,
+      fontWeight: voted ? 700 : 600,
+      showLabel: true,
+    },
+    float: {
+      iconSize: 18,
+      padding: "13px 20px",
+      borderRadius: voted ? 12 : 24,
+      fontSize: T.body,
+      fontWeight: voted ? 700 : 600,
+      showLabel: true,
+    },
+  };
+
+  const cfg = sizeConfig[size];
 
   return (
     <button
       ref={btnRef}
       onClick={handleClick}
-      className={popActive ? "vote-pop-active" : ""}
+      className={[popActive ? "vote-pop-active" : "", className].filter(Boolean).join(" ") || undefined}
       style={{
         display: "flex",
-        flexDirection: isLarge ? "column" : "row",
+        flexDirection: size === "large" ? "column" : "row",
         alignItems: "center",
-        gap: isLarge ? 2 : 4,
+        justifyContent: size === "float" ? "center" : undefined,
+        gap: size === "large" ? 2 : 8,
         background: voted ? C.accent : "transparent",
-        borderRadius: isLarge ? 10 : 20,
-        padding: isLarge ? "10px 18px" : "6px 14px",
-        border: voted ? `1.5px solid ${C.accent}` : `1px solid ${C.border}`,
+        borderRadius: cfg.borderRadius,
+        padding: cfg.padding,
+        border: voted ? `1.5px solid ${C.accent}` : `1.5px solid ${C.border}`,
         cursor: "pointer",
-        transition: "border 0.25s, background 0.25s, color 0.25s",
+        transition: "all 0.25s",
         opacity: loading ? 0.6 : 1,
         fontFamily: "var(--sans)",
         color: voted ? C.accentFg : C.text,
         position: "relative",
         overflow: "visible",
+        ...extraStyle,
       }}
+      onMouseEnter={e => { e.currentTarget.style.opacity = "0.85"; }}
+      onMouseLeave={e => { e.currentTarget.style.opacity = "1"; }}
     >
-      <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" style={{ display: "block", transition: "all 0.2s" }}>
+      <svg width={cfg.iconSize} height={cfg.iconSize} viewBox="0 0 24 24" fill="none" style={{ display: "block", transition: "all 0.2s" }}>
         <path d="M10.6 4.4a1.6 1.6 0 0 1 2.8 0l8.4 14.2A1.6 1.6 0 0 1 20.4 21H3.6a1.6 1.6 0 0 1-1.4-2.4L10.6 4.4Z" fill={voted ? "currentColor" : "none"} stroke="currentColor" strokeWidth={voted ? 0 : 2} strokeLinejoin="round" strokeLinecap="round" />
       </svg>
-      <span
-        style={{
-          fontSize: isLarge ? T.subtitle : T.bodySm,
-          fontWeight: 650,
-          color: voted ? C.accentFg : C.text,
-        }}
-      >
-        {fmt(weighted)}
+      <span style={{ fontSize: cfg.fontSize, fontWeight: cfg.fontWeight, color: voted ? C.accentFg : C.text, lineHeight: 1 }}>
+        {cfg.showLabel && voted ? "Voted \u00B7 " : ""}{fmt(weighted)}
       </span>
     </button>
   );


### PR DESCRIPTION
## Summary
- Replace 2 inline vote buttons in ProjectDetailClient with shared UpvoteButton
- Added size variants: "detail" (desktop), "float" (mobile), "default" (list), "large"
- All contexts now share the same outline/filled styling and burst animation
- Added onVoteForButton wrapper to bridge page-level state with component API

## Test plan
- [ ] Desktop detail page: outline pill before voting, filled after
- [ ] Mobile floating bar: same behavior
- [ ] Project list: existing UpvoteButton still works
- [ ] Burst particle animation fires on first vote in all contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)