### PR TITLE
refactor: single UpvoteButton everywhere — nav, detail, list

### DIFF
--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -17,6 +17,7 @@ import { useResponsive } from "@/hooks/useMediaQuery";
 import { useTheme } from "@/context/ThemeContext";
 import BuiltLogo from "@/components/BuiltLogo";
 import NotificationBell from "@/components/NotificationBell";
+import UpvoteButton from "@/components/UpvoteButton";
 
 function Av({ initials, size = 32, role, src }: { initials: string; size?: number; role?: string; src?: string }) {
   const r = role ? ROLES[role] : undefined;
@@ -171,24 +172,13 @@ export default function AppNav() {
               <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
                 {user && <NotificationBell />}
                 {voteState && showVoteInNav ? (
-                  <button
-                    onClick={voteState.onVote}
-                    style={{
-                      display: "flex", alignItems: "center", gap: 5,
-                      padding: "5px 12px", borderRadius: 8,
-                      border: `1.5px solid ${C.accent}`,
-                      background: voteState.hasVoted ? C.accent : C.surface,
-                      cursor: "pointer", fontSize: T.label, fontWeight: 650,
-                      fontFamily: "var(--sans)",
-                      color: voteState.hasVoted ? C.accentFg : C.text,
-                      transition: "all 0.25s",
-                    }}
-                  >
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
-                      <path d="M10.6 7.4a1.6 1.6 0 0 1 2.8 0l6.4 10.8A1.6 1.6 0 0 1 18.4 20H5.6a1.6 1.6 0 0 1-1.4-2.4L10.6 7.4Z" fill={voteState.hasVoted ? "currentColor" : "none"} stroke="currentColor" strokeWidth={voteState.hasVoted ? 0 : 2} strokeLinejoin="round" strokeLinecap="round" />
-                    </svg>
-                    <span style={{ lineHeight: 1 }}>{voteState.count.toLocaleString()}</span>
-                  </button>
+                  <UpvoteButton
+                    projectId={voteState.projectId}
+                    weighted={voteState.count}
+                    hasVoted={voteState.hasVoted}
+                    onVote={voteState.onVote}
+                    onUnauthClick={voteState.onUnauthClick}
+                  />
                 ) : (
                   <button
                     onClick={() => router.push("/?submit=1")}
@@ -242,27 +232,20 @@ export default function AppNav() {
               <div style={{ position: "absolute", right: 96, top: 0, height: 65, display: "flex", alignItems: "center", gap: 14, zIndex: 1 }}>
                 {/* Vote button in nav — desktop */}
                 {voteState && (
-                  <button
-                    onClick={voteState.onVote}
-                    style={{
-                      display: "flex", alignItems: "center", gap: 6,
-                      padding: "6px 14px", borderRadius: 8,
-                      border: `1.5px solid ${C.accent}`,
-                      background: voteState.hasVoted ? C.accent : C.surface,
-                      cursor: "pointer", fontSize: T.bodySm, fontWeight: 650,
-                      fontFamily: "var(--sans)",
-                      color: voteState.hasVoted ? C.accentFg : C.text,
-                      transition: "all 0.3s ease",
-                      opacity: showVoteInNav ? 1 : 0,
-                      transform: showVoteInNav ? "translateY(0)" : "translateY(-4px)",
-                      pointerEvents: showVoteInNav ? "auto" : "none",
-                    }}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
-                      <path d="M10.6 7.4a1.6 1.6 0 0 1 2.8 0l6.4 10.8A1.6 1.6 0 0 1 18.4 20H5.6a1.6 1.6 0 0 1-1.4-2.4L10.6 7.4Z" fill={voteState.hasVoted ? "currentColor" : "none"} stroke="currentColor" strokeWidth={voteState.hasVoted ? 0 : 2} strokeLinejoin="round" strokeLinecap="round" />
-                    </svg>
-                    <span style={{ lineHeight: 1 }}>{voteState.count.toLocaleString()}</span>
-                  </button>
+                  <div style={{
+                    transition: "all 0.3s ease",
+                    opacity: showVoteInNav ? 1 : 0,
+                    transform: showVoteInNav ? "translateY(0)" : "translateY(-4px)",
+                    pointerEvents: showVoteInNav ? "auto" : "none",
+                  }}>
+                    <UpvoteButton
+                      projectId={voteState.projectId}
+                      weighted={voteState.count}
+                      hasVoted={voteState.hasVoted}
+                      onVote={voteState.onVote}
+                      onUnauthClick={voteState.onUnauthClick}
+                    />
+                  </div>
                 )}
                 {/* Notification bell — desktop, logged in only */}
                 {user && <NotificationBell />}

--- a/components/ProjectDetailClient.tsx
+++ b/components/ProjectDetailClient.tsx
@@ -354,7 +354,13 @@ export default function ProjectDetailPage() {
   const handleVoteRef = useRef<() => void>(() => {});
   useEffect(() => {
     if (project) {
-      setVoteState({ hasVoted, count: project.weighted, onVote: () => handleVoteRef.current() });
+      setVoteState({
+        projectId: project._id || project.id,
+        hasVoted,
+        count: project.weighted,
+        onVote: onVoteForButton,
+        onUnauthClick: () => openLoginDialog(() => { reloadUser(); reloadComments(); }),
+      });
     }
     return () => setVoteState(null);
   }, [project, hasVoted, setVoteState]);

--- a/context/NavContext.tsx
+++ b/context/NavContext.tsx
@@ -3,9 +3,11 @@
 import { createContext, useContext, useState, useCallback, useRef } from "react";
 
 interface VoteState {
+  projectId: string | number;
   hasVoted: boolean;
   count: number;
-  onVote: () => void;
+  onVote: (id: string | number) => Promise<{ voted: boolean; weighted: number; raw: number } | null>;
+  onUnauthClick?: () => void;
 }
 
 interface NavOverride {


### PR DESCRIPTION
## Summary
- Replace inline vote buttons in AppNav (mobile + desktop) with UpvoteButton
- Updated VoteState in NavContext to carry UpvoteButton-compatible props
- All 5 vote button contexts now use the same component
- Non-voted state: outline pill with △ + count everywhere

## Test plan
- [ ] Nav scroll vote button uses outline pill style
- [ ] Detail page vote button uses outline pill
- [ ] Mobile floating bar vote button uses outline pill
- [ ] Project list vote buttons unchanged (already used UpvoteButton)
- [ ] Voting transitions work in all contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)