### PR TITLE
feat(routes/events): append OpenCode buildathon card

### DIFF
--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -36,6 +36,14 @@ const EVENTS: EventCardProps[] = [
     status: "live",
     href: "/ai-weekender",
   },
+  {
+    slug: "opencode",
+    title: "India's First OpenCode Buildathon by GrowthX",
+    tagline: "open source, shipped in a weekend.",
+    dateRange: "April 2026",
+    status: "archived",
+    href: "/opencode",
+  },
 ];
 
 export default function EventsPage() {


### PR DESCRIPTION
## Summary
- Appends `India's First OpenCode Buildathon by GrowthX` (status: archived) to the events hub
- Links to /opencode (PR-B in parallel)
- Live project count auto-updates once PR-A's backfill runs

## Land order
**Merge PR-B first, THEN PR-C.** This card links to /opencode; if /opencode doesn't exist yet, the card 404s on click.

## Test plan
- [ ] /events renders 2 cards: AI Weekender (live) + OpenCode (archived)
- [ ] Clicking OpenCode card navigates to /opencode
- [ ] Card shows project count once PR-A's backfill runs (currently `No projects yet`)
- [ ] AIWK card unchanged