### PR TITLE
fix(opencode): update event name + tagline copy

### DIFF
--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -38,8 +38,8 @@ const EVENTS: EventCardProps[] = [
   },
   {
     slug: "opencode",
-    title: "India's First OpenCode Buildathon by GrowthX",
-    tagline: "open source, shipped in a weekend.",
+    title: "OpenCode Buildathon",
+    tagline: "India's first OpenCode Buildathon, powered by GrowthX.",
     dateRange: "April 2026",
     status: "archived",
     href: "/opencode",

--- a/app/routes/opencode.tsx
+++ b/app/routes/opencode.tsx
@@ -4,25 +4,25 @@ import { useResponsive } from "@/hooks/useMediaQuery";
 import ProjectListView from "@/components/ProjectListView";
 
 export const meta: MetaFunction = () => [
-  { title: "India's First OpenCode Buildathon · Built at GrowthX" },
+  { title: "OpenCode Buildathon · Built at GrowthX" },
   {
     name: "description",
     content:
-      "Projects shipped at India's First OpenCode Buildathon by GrowthX — open source, in a weekend.",
+      "India's first OpenCode Buildathon, powered by GrowthX. Projects shipped during the event.",
   },
   { property: "og:type", content: "website" },
-  { property: "og:title", content: "India's First OpenCode Buildathon · Built at GrowthX" },
+  { property: "og:title", content: "OpenCode Buildathon · Built at GrowthX" },
   {
     property: "og:description",
     content:
-      "Projects shipped at India's First OpenCode Buildathon by GrowthX — open source, in a weekend.",
+      "India's first OpenCode Buildathon, powered by GrowthX. Projects shipped during the event.",
   },
   { name: "twitter:card", content: "summary" },
-  { name: "twitter:title", content: "India's First OpenCode Buildathon · Built at GrowthX" },
+  { name: "twitter:title", content: "OpenCode Buildathon · Built at GrowthX" },
   {
     name: "twitter:description",
     content:
-      "Projects shipped at India's First OpenCode Buildathon by GrowthX — open source, in a weekend.",
+      "India's first OpenCode Buildathon, powered by GrowthX. Projects shipped during the event.",
   },
   { tagName: "link", rel: "canonical", href: "https://built.growthx.club/opencode" },
 ];
@@ -39,8 +39,8 @@ export default function OpenCodePage() {
       }}>
         <main className="responsive-main" style={{ padding: isMobile ? "20px 16px 80px" : isTablet ? "32px 32px 100px" : "32px 0 100px" }}>
           <ProjectListView
-            headerTitle="India's First OpenCode Buildathon"
-            headerSubtitle="Open source, shipped in a weekend. By GrowthX."
+            headerTitle="OpenCode Buildathon"
+            headerSubtitle="India's first OpenCode Buildathon, powered by GrowthX."
             buildathonFilter="opencode"
             emptyState={{
               icon: "🛠️",


### PR DESCRIPTION
## Summary
- Events tab card: title `OpenCode Buildathon`, tagline `India's first OpenCode Buildathon, powered by GrowthX.`
- /opencode page header (h1) + meta tags + og/twitter all updated to match
- Per-project AI taglines on individual BxProjects unchanged

## Test plan
- [ ] /events shows "OpenCode Buildathon" + new tagline
- [ ] /opencode page h1 reads "OpenCode Buildathon"
- [ ] meta title in browser tab reads "OpenCode Buildathon · Built at GrowthX"