### PR TITLE
feat(projects): render track chip + accolade badge on cards

### DIFF
--- a/components/AccoladeBadge.tsx
+++ b/components/AccoladeBadge.tsx
@@ -1,0 +1,91 @@
+import { C, T } from "@/types";
+
+export interface AccoladeBadgeProps {
+  accolade: 'rank-1' | 'rank-2' | 'rank-3' | 'top-5' | 'top-15';
+}
+
+// Tiered, slightly more prominent pill. Designed to feel earned but not
+// gaudy on the warm cream surface (~#F8F7F4). Top-5 / Top-15 are
+// informational tones, not gold/silver/bronze.
+type Tier = {
+  label: string;
+  bg: string;
+  color: string;
+  border?: string;
+  weight: number;
+  letterSpacing: string;
+};
+
+// Inline silver/bronze tones — tokens don't include them. Picked to sit
+// quietly on the warm cream palette without screaming for attention.
+const SILVER = "#9CA0A4";
+const BRONZE = "#B07746";
+
+const TIERS: Record<AccoladeBadgeProps['accolade'], Tier> = {
+  'rank-1': {
+    label: "1st",
+    bg: C.gold,
+    color: "#FFFFFF",
+    weight: 700,
+    letterSpacing: "0.06em",
+  },
+  'rank-2': {
+    label: "2nd",
+    bg: SILVER,
+    color: "#FFFFFF",
+    weight: 700,
+    letterSpacing: "0.06em",
+  },
+  'rank-3': {
+    label: "3rd",
+    bg: BRONZE,
+    color: "#FFFFFF",
+    weight: 700,
+    letterSpacing: "0.06em",
+  },
+  'top-5': {
+    label: "Top 5",
+    bg: C.text,
+    color: "#FFFFFF",
+    weight: 600,
+    letterSpacing: "0.04em",
+  },
+  'top-15': {
+    label: "Top 15",
+    bg: "transparent",
+    color: C.textSec,
+    border: C.borderLight,
+    weight: 600,
+    letterSpacing: "0.04em",
+  },
+};
+
+export default function AccoladeBadge({ accolade }: AccoladeBadgeProps) {
+  const t = TIERS[accolade];
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "4px 10px",
+        borderRadius: 999,
+        background: t.bg,
+        color: t.color,
+        border: t.border ? `1px solid ${t.border}` : "none",
+        fontSize: T.badge,
+        fontWeight: t.weight,
+        fontFamily: "var(--sans)",
+        letterSpacing: t.letterSpacing,
+        lineHeight: 1.1,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {accolade === 'rank-1' && (
+        <span aria-hidden="true" style={{ fontSize: T.badge, lineHeight: 1 }}>{"★"}</span>
+      )}
+      {t.label}
+    </span>
+  );
+}

--- a/components/ProjectListView.tsx
+++ b/components/ProjectListView.tsx
@@ -13,6 +13,22 @@ import { bxApi } from "@/lib/api";
 import { useLoginDialog } from "@/context/LoginDialogContext";
 import { useResponsive } from "@/hooks/useMediaQuery";
 import ProjectIcon from "@/components/ProjectIcon";
+import TrackChip from "@/components/TrackChip";
+import AccoladeBadge from "@/components/AccoladeBadge";
+
+// Renders the accolade + track meta row when either field is set.
+// Returns null when neither is set, so the caller doesn't have to add an empty container.
+function ProjectMetaRow({ project }: { project: Project }) {
+  const accolade = project.accolade;
+  const track = project.track;
+  if (!accolade && !track) return null;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", marginTop: 6 }}>
+      {accolade && <AccoladeBadge accolade={accolade} />}
+      {track && <TrackChip track={track} />}
+    </div>
+  );
+}
 
 // ---- Builder cycler (extracted from _index to share between feeds) ----
 
@@ -428,6 +444,11 @@ export default function ProjectListView({
                   <div style={{ fontSize: T.body, color: C.textSec, fontFamily: "var(--sans)", fontWeight: 400 }}>
                     {fp.tagline}
                   </div>
+                  {fp.accolade && (
+                    <div style={{ marginTop: 8 }}>
+                      <AccoladeBadge accolade={fp.accolade} />
+                    </div>
+                  )}
                 </div>
                 <div style={{
                   fontSize: T.heading, fontWeight: 400, color: C.text, fontFamily: "var(--serif)",
@@ -468,6 +489,7 @@ export default function ProjectListView({
                     }}>
                       {p.tagline}
                     </div>
+                    <ProjectMetaRow project={p} />
                   </div>
                 </div>
 
@@ -488,6 +510,7 @@ export default function ProjectListView({
                       }}>
                         {p.tagline}
                       </div>
+                      <ProjectMetaRow project={p} />
                     </div>
                   </div>
                   <div

--- a/components/TrackChip.tsx
+++ b/components/TrackChip.tsx
@@ -1,0 +1,53 @@
+import { C, T } from "@/types";
+
+export interface TrackChipProps {
+  track: 'virality' | 'revenue' | 'maas';
+}
+
+// Subtle warm pill that labels a project's track. Sits next to the more
+// prominent AccoladeBadge — should NOT compete with it visually.
+const TRACK_STYLES: Record<TrackChipProps['track'], { label: string; color: string; bg: string; border: string }> = {
+  virality: {
+    label: "Virality",
+    color: C.gold,
+    bg: C.goldSoft,
+    border: C.goldBorder,
+  },
+  revenue: {
+    label: "Revenue",
+    color: C.green,
+    bg: C.greenSoft,
+    border: C.greenSoft,
+  },
+  maas: {
+    label: "MaaS",
+    color: C.blue,
+    bg: C.blueSoft,
+    border: C.blueSoft,
+  },
+};
+
+export default function TrackChip({ track }: TrackChipProps) {
+  const s = TRACK_STYLES[track];
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "3px 9px",
+        borderRadius: 999,
+        background: s.bg,
+        color: s.color,
+        border: `1px solid ${s.border}`,
+        fontSize: T.badge,
+        fontWeight: 500,
+        fontFamily: "var(--sans)",
+        letterSpacing: "0.02em",
+        lineHeight: 1.1,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -104,6 +104,9 @@ export interface MediaItem {
   url: string;
 }
 
+export type ProjectTrack = 'virality' | 'revenue' | 'maas' | null;
+export type ProjectAccolade = 'rank-1' | 'rank-2' | 'rank-3' | 'top-5' | 'top-15' | null;
+
 export interface Project {
   id: string | number;
   _id?: string;
@@ -129,6 +132,10 @@ export interface Project {
   buildProcess?: string;
   isDraft?: boolean;
   enabled: boolean;
+  /** Project track classification (nullable — server may not populate). */
+  track?: ProjectTrack;
+  /** Project accolade / ranking (nullable — server may not populate). */
+  accolade?: ProjectAccolade;
 }
 
 export interface BuildingProject {
@@ -392,7 +399,26 @@ export function normalizeProject(p: Record<string, unknown>): Project {
     buildProcess: (p.buildProcess ?? p.build_process ?? undefined) as string | undefined,
     isDraft: (p.isDraft ?? p.is_draft ?? false) as boolean,
     enabled: (p.enabled !== undefined ? p.enabled : true) as boolean,
+    track: normalizeTrack(p.track),
+    accolade: normalizeAccolade(p.accolade),
   };
+}
+
+const VALID_TRACKS = new Set<NonNullable<ProjectTrack>>(['virality', 'revenue', 'maas']);
+const VALID_ACCOLADES = new Set<NonNullable<ProjectAccolade>>([
+  'rank-1', 'rank-2', 'rank-3', 'top-5', 'top-15',
+]);
+
+function normalizeTrack(raw: unknown): ProjectTrack {
+  if (typeof raw !== 'string') return null;
+  const v = raw.toLowerCase();
+  return VALID_TRACKS.has(v as NonNullable<ProjectTrack>) ? (v as NonNullable<ProjectTrack>) : null;
+}
+
+function normalizeAccolade(raw: unknown): ProjectAccolade {
+  if (typeof raw !== 'string') return null;
+  const v = raw.toLowerCase();
+  return VALID_ACCOLADES.has(v as NonNullable<ProjectAccolade>) ? (v as NonNullable<ProjectAccolade>) : null;
 }
 
 /** Normalize backend /me response to BuilderProfile */


### PR DESCRIPTION
## Summary
- Adds optional `track` (Virality / Revenue / MaaS) and `accolade` (rank-1, rank-2, rank-3, top-5, top-15) fields to the `Project` type and pipes them through `normalizeProject`.
- New `TrackChip` (subtle warm pill) and `AccoladeBadge` (tiered: gold 1st, silver 2nd, bronze 3rd, dark Top 5, outlined Top 15) components.
- Renders a meta row beneath the tagline on every project card in `ProjectListView` — applies automatically to `/`, `/ai-weekender`, `/opencode`. Host-pick card shows the accolade only.
- Both fields are nullable; when both are null no row renders.

Coordinated with PR-D which adds the matching `track` / `accolade` schema fields to gx-backend. Frontend tolerates missing values, so this PR is safe to ship before PR-D lands.

## Test plan
- [ ] Vercel preview: confirm cards on `/`, `/ai-weekender`, `/opencode` render unchanged when API returns no `track` / `accolade`.
- [ ] Once PR-D ships and a project has `accolade: 'rank-1'`, verify gold "1st" pill renders next to the project name on all three routes.
- [ ] Verify host-pick card shows accolade badge below tagline when set.
- [ ] Verify chip + badge sit side-by-side and wrap on narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)