### PR TITLE
fix(opencode): cap fetch limit at 100; horizontal scroll on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -319,6 +319,9 @@ body {
   background: var(--c-scrollHover);
 }
 
+/* Hide horizontal scrollbar on the filter-pill row — looks cleaner */
+.filter-pills-row::-webkit-scrollbar { display: none; height: 0; }
+
 /* Nav spacer — matches nav height per breakpoint */
 .nav-spacer { height: 65px; background: var(--c-bg); }
 

--- a/components/ProjectListView.tsx
+++ b/components/ProjectListView.tsx
@@ -211,7 +211,8 @@ export default function ProjectListView({
     loadingMoreRef.current = false;
     // In custom-filter mode we fetch the full set in one request and skip
     // server sort + infinite scroll; the predicates run client-side.
-    const limit = usingCustomFilters ? 200 : PAGE_SIZE;
+    // Backend Joi caps `limit` at 100 — that's enough for OpenCode (~84 docs).
+    const limit = usingCustomFilters ? 100 : PAGE_SIZE;
     const sortParam = usingCustomFilters ? "" : `&sort=${sortMode}`;
     bxApi(`/projects?limit=${limit}&offset=0${sortParam}${filterSuffix}`)
       .then((r) => r.json())
@@ -384,7 +385,25 @@ export default function ProjectListView({
       </div>
 
       {/* Sort / filter tabs */}
-      <div style={{ display: "flex", gap: 6, marginBottom: 24, flexWrap: "wrap" }}>
+      <div
+        style={
+          usingCustomFilters
+            ? {
+                display: "flex",
+                gap: 6,
+                marginBottom: 24,
+                overflowX: "auto",
+                WebkitOverflowScrolling: "touch",
+                scrollbarWidth: "none",
+                msOverflowStyle: "none",
+                paddingBottom: 4,
+                margin: isMobile ? "0 -16px 24px" : "0 0 24px",
+                paddingInline: isMobile ? 16 : 0,
+              }
+            : { display: "flex", gap: 6, marginBottom: 24 }
+        }
+        className={usingCustomFilters ? "filter-pills-row" : undefined}
+      >
         {usingCustomFilters
           ? customFilters!.map(tab => {
               const active = selectedFilterKey === tab.key;
@@ -400,6 +419,8 @@ export default function ProjectListView({
                     color: active ? C.accentFg : C.textSec,
                     fontSize: T.bodySm, fontWeight: 550, fontFamily: "var(--sans)",
                     cursor: "pointer", transition: "all 0.2s",
+                    flexShrink: 0,
+                    whiteSpace: "nowrap",
                   }}
                 >
                   {tab.label}


### PR DESCRIPTION
## Summary
Two bugs from PR #75:

1. **Empty list on every filter** — backend Joi caps \`limit\` at 100 but the custom-filter fetch was sending 200, returning a 400 BAD_REQUEST and zero projects. OpenCode has 84 docs so 100 is enough. Dropping to 100.
2. **Cramped filter pills on mobile** — six pills with \`flexWrap: wrap\` rendered as a 2-row mess. Switched to horizontal scroll (overflow-x auto, scrollbar hidden, native momentum scroll on touch). Pills extend edge-to-edge on mobile via negative margin.

## Test plan
- [ ] /opencode shows all 84 projects under "All projects"
- [ ] Top 5 → 5 projects (Mango Giraffe, Team Kitana, CampAI, BiasCast, Vikings)
- [ ] Top 15 → 18 projects
- [ ] Mobile pills scroll horizontally without wrapping