### PR TITLE
fix(builders): fetch builder's projects via creator filter

### DIFF
--- a/app/routes/builders.tsx
+++ b/app/routes/builders.tsx
@@ -129,8 +129,9 @@ export default function BuildersPage() {
   const openBuilderDialog = (b: BuilderProfile) => {
     setSelectedBuilder(b);
     setBuilderProjects([]);
+    if (!b._id) return;
     setLoadingProjects(true);
-    bxApi(`/projects?creator=${encodeURIComponent(b._id || "")}&limit=100`)
+    bxApi(`/projects?creator=${encodeURIComponent(b._id)}&limit=100`)
       .then(r => r.json())
       .then(d => {
         const all = (d.projects || []).map((p: Record<string, unknown>) => normalizeProject(p));

--- a/app/routes/builders.tsx
+++ b/app/routes/builders.tsx
@@ -130,18 +130,11 @@ export default function BuildersPage() {
     setSelectedBuilder(b);
     setBuilderProjects([]);
     setLoadingProjects(true);
-    bxApi("/projects?limit=100")
+    bxApi(`/projects?creator=${encodeURIComponent(b._id || "")}&limit=100`)
       .then(r => r.json())
       .then(d => {
-        const all = (d.projects || []).map((p: Record<string, unknown>) => normalizeProject(p))
-          .filter((p: Project) => p.enabled !== false);
-        const matched = all.filter((p: Project) => {
-          if (p.builder?.name === b.name) return true;
-          if ((p.creators || []).some(c => c.name === b.name)) return true;
-          if (p.collabs?.some(c => c.name === b.name)) return true;
-          return false;
-        });
-        setBuilderProjects(matched);
+        const all = (d.projects || []).map((p: Record<string, unknown>) => normalizeProject(p));
+        setBuilderProjects(all);
       })
       .finally(() => setLoadingProjects(false));
   };
@@ -302,7 +295,7 @@ export default function BuildersPage() {
               ) : (
                 <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                   {builderProjects.map(p => {
-                    const isCreator = p.builder?.name === selectedBuilder.name || (p.creators || []).some(c => c.name === selectedBuilder.name);
+                    const isCreator = p.builder?._id === selectedBuilder._id || (p.creators || []).some(c => c._id === selectedBuilder._id);
                     return (
                       <div
                         key={p.id}


### PR DESCRIPTION
## Summary

- Dialog now hits `/bx/projects?creator=<id>&limit=100` instead of paginating the full feed and matching by builder name client-side.
- Switches the Creator/Collaborator label from name comparison to `_id` comparison.

## Why

The dialog under-counted: row badge said "3 shipped", dialog showed 2 (udayan). Cause: 340+ enabled projects sorted by votes desc; lower-voted projects of a given builder fell past the limit-100 cutoff. Name-based matching was also fragile when two users share a name.

## Depends on

[gx-backend#3051](https://github.com/GrowthX-Club/gx-backend/pull/3051) — adds the `creator` query param. Merge that first; this frontend change will 400 until the backend deploys.

## Test plan

- [ ] After backend deploy: open /builders, click udayan → dialog shows 3 projects (matches "3 shipped" badge).
- [ ] Open dialog for any builder with co-authored projects → they show up with "Collaborator" label.
- [ ] Two users with the same name aren't conflated (e.g., if "test" exists twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)