### PR TITLE
feat(sarvam): Sarvam Epoch Buildathon showcase route

### DIFF
--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -29,6 +29,14 @@ export const meta: MetaFunction = () => [
 
 const EVENTS: EventCardProps[] = [
   {
+    slug: "sarvam",
+    title: "Sarvam Epoch Buildathon",
+    tagline: "~600 builders shipping with Sarvam AI in a single day.",
+    dateRange: "July 2026",
+    status: "live",
+    href: "/sarvam",
+  },
+  {
     slug: "ai-weekender",
     title: "AI Weekender Buildathon",
     tagline: "Ship an AI product over the weekend. Build, prove, win.",

--- a/app/routes/sarvam.tsx
+++ b/app/routes/sarvam.tsx
@@ -1,0 +1,56 @@
+import type { MetaFunction } from "react-router";
+import { C } from "@/types";
+import { useResponsive } from "@/hooks/useMediaQuery";
+import ProjectListView from "@/components/ProjectListView";
+
+export const meta: MetaFunction = () => [
+  { title: "Sarvam Epoch Buildathon · Built at GrowthX" },
+  {
+    name: "description",
+    content:
+      "Sarvam Epoch Buildathon, powered by GrowthX — ~600 builders, one day, built with Sarvam AI. Projects shipped during the event.",
+  },
+  { property: "og:type", content: "website" },
+  { property: "og:title", content: "Sarvam Epoch Buildathon · Built at GrowthX" },
+  {
+    property: "og:description",
+    content:
+      "Sarvam Epoch Buildathon, powered by GrowthX — ~600 builders, one day, built with Sarvam AI. Projects shipped during the event.",
+  },
+  { name: "twitter:card", content: "summary" },
+  { name: "twitter:title", content: "Sarvam Epoch Buildathon · Built at GrowthX" },
+  {
+    name: "twitter:description",
+    content:
+      "Sarvam Epoch Buildathon, powered by GrowthX — ~600 builders, one day, built with Sarvam AI. Projects shipped during the event.",
+  },
+  { tagName: "link", rel: "canonical", href: "https://built.growthx.club/sarvam" },
+];
+
+export default function SarvamPage() {
+  const { isMobile, isTablet } = useResponsive();
+
+  return (
+    <div style={{ minHeight: "100vh", background: C.bg, fontFamily: "var(--sans)" }}>
+      <div style={{
+        maxWidth: isMobile || isTablet ? 960 : 960,
+        margin: "0 auto",
+        padding: isMobile ? "0" : isTablet ? "0" : "0 32px",
+      }}>
+        <main className="responsive-main" style={{ padding: isMobile ? "20px 16px 80px" : isTablet ? "32px 32px 100px" : "32px 0 100px" }}>
+          <ProjectListView
+            headerTitle="Sarvam Epoch Buildathon"
+            headerSubtitle="One-day buildathon on 26 July 2026 — ~600 builders shipping with Sarvam AI."
+            buildathonFilter="sarvam"
+            featuredEnabled={false}
+            emptyState={{
+              icon: "🛠️",
+              title: "No Sarvam Epoch projects yet",
+              description: "Projects from the buildathon are being added — check back soon.",
+            }}
+          />
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/sarvam` showcase route mirroring `/opencode`, rendering `bx_projects` with `buildathon: 'sarvam'` (backend backfill of ~220 projects from the Sarvam Epoch Buildathon, 26 July 2026, ~600 builders building with Sarvam AI).
- Canonical URL `https://built.growthx.club/sarvam`; full SEO/OG/Twitter meta in the same shape as the opencode page.
- Uses default Trending/New/Top sort tabs with pagination instead of opencode's custom track filters: sarvam projects have `track: null` (tracks/accolades are opencode-specific), and custom-filter mode fetches a single request capped at limit 100, which would truncate the ~220-project batch.
- List the event on `/events` (EventCard fetches the live project count via `?buildathon=sarvam`).

No label map exists for buildathon tags (detail pages render the raw `buildathon` string), and mock mode's `/projects` handler ignores the `buildathon` param for all buildathons, so no changes needed there. Route registration is automatic via `flatRoutes()`.

## Test plan
- [x] `npm run build` passes; `sarvam` chunk emitted in `build/client/assets`
- [x] `npm run typecheck` — error list identical to `origin/main` baseline (8 pre-existing errors in dead Next-era components; none in changed files)
- [x] Dev server in mock mode (`VITE_MOCK_MODE=true`): `GET /sarvam` returns 200 with SSR title, canonical link, and page copy; `/events` shows the Sarvam card
- [ ] After backend backfill lands: verify live project list and count on `/sarvam` and `/events` in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvHQy8eieamvpaeqtHfT9A