### PR TITLE
fix(detail): markdown rendering, video embeds, date + buildathon labels

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -29,7 +29,7 @@ export default function HomePage() {
     name: "", tagline: "", description: "", buildProcess: "",
     stack: [] as string[], stackInput: "",
     team: [] as { _id: string; name: string; avatar?: string; company?: string; companyColor?: string; role: 'creator' | 'collaborator' }[], teamInput: "",
-    url: "", isDraft: false, mediaFiles: [] as { url: string; type: "image" | "loom"; uploading?: boolean; progress?: string }[],
+    url: "", isDraft: false, mediaFiles: [] as { url: string; type: "image" | "loom" | "youtube"; uploading?: boolean; progress?: string }[],
   });
   const [submitError, setSubmitError] = useState("");
   const [submitting, setSubmitting] = useState(false);

--- a/app/routes/my-projects.tsx
+++ b/app/routes/my-projects.tsx
@@ -68,7 +68,7 @@ interface EditState {
   stackInput: string;
   team: CollabEntry[];
   teamInput: string;
-  mediaFiles: { url: string; type: "image" | "loom"; uploading?: boolean; progress?: string }[];
+  mediaFiles: { url: string; type: "image" | "loom" | "youtube"; uploading?: boolean; progress?: string }[];
 }
 
 export default function MyProjectsPage() {
@@ -174,7 +174,7 @@ export default function MyProjectsPage() {
       teamInput: "",
       mediaFiles: (p.media || []).map((m: { url: string; type?: string }) => ({
         url: m.url,
-        type: (m.type === "loom" ? "loom" : "image") as "image" | "loom",
+        type: (m.type === "loom" || m.type === "youtube" ? m.type : "image") as "image" | "loom" | "youtube",
       })),
     });
   };

--- a/app/routes/my-projects.tsx
+++ b/app/routes/my-projects.tsx
@@ -14,7 +14,7 @@ import {
 import { bxApi } from "@/lib/api";
 import { useLoginDialog } from "@/context/LoginDialogContext";
 import { useNavOverride } from "@/context/NavContext";
-import { extractPlainText, descriptionCharCount } from "@/lib/editor-utils";
+import { extractPlainText, stripMarkdownLite, descriptionCharCount } from "@/lib/editor-utils";
 import RichTextEditor from "@/components/RichTextEditor";
 import MediaUpload from "@/components/MediaUpload";
 
@@ -814,7 +814,7 @@ export default function MyProjectsPage() {
                       </div>
                     </div>
                     {p.description && (() => {
-                      const plain = extractPlainText(p.description);
+                      const plain = stripMarkdownLite(extractPlainText(p.description));
                       return plain ? (
                         <p style={{ fontSize: T.bodySm, color: C.textMute, fontFamily: "var(--sans)", margin: "8px 0 0", lineHeight: 1.5 }}>
                           {plain.length > 150 ? plain.slice(0, 150) + "..." : plain}

--- a/app/routes/projects.$id.tsx
+++ b/app/routes/projects.$id.tsx
@@ -1,6 +1,13 @@
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { redirect } from "react-router";
 import ProjectDetailClient from "@/components/ProjectDetailClient";
+import { extractPlainText, stripMarkdownLite } from "@/lib/editor-utils";
+
+/** Plain, marker-free, single-line text for meta/JSON-LD descriptions */
+function cleanDescription(raw: unknown): string {
+  if (typeof raw !== "string" || !raw) return "";
+  return stripMarkdownLite(extractPlainText(raw)).replace(/\s+/g, " ").trim();
+}
 
 const API_BASE =
   typeof process !== "undefined" && process.env?.VITE_API_URL
@@ -39,7 +46,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   const project = data.project;
   const title = project.name || "Project";
   const description =
-    project.tagline || project.description || "A project built at GrowthX";
+    project.tagline || cleanDescription(project.description) || "A project built at GrowthX";
   const builderName = project.builderName || project.builder?.name || "";
   const fullDescription = builderName
     ? `${description} — by ${builderName}`
@@ -52,7 +59,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     name: title,
-    description: project.description || project.tagline || "",
+    description: cleanDescription(project.description) || project.tagline || "",
     url: `https://built.growthx.club/projects/${canonicalSlug}`,
     applicationCategory: project.category || "WebApplication",
     ...(project.icon ? { image: project.icon } : {}),

--- a/components/MediaGallery.tsx
+++ b/components/MediaGallery.tsx
@@ -1,18 +1,21 @@
 import { useState } from "react";
-import { C, T, getYouTubeVideoId, isVideoMedia, type MediaItem } from "@/types";
+import { C, T, getLoomVideoId, getYouTubeVideoId, type MediaItem } from "@/types";
 
-/** Convert a loom.com/share URL to an embeddable URL */
-function toLoomEmbed(url: string): string {
-  const match = url.match(/loom\.com\/(?:share|embed)\/([a-zA-Z0-9]+)/);
-  if (!match) return url;
-  return `https://www.loom.com/embed/${match[1]}`;
-}
-
-/** Convert a YouTube watch/short URL to a privacy-enhanced embed URL */
-function toYouTubeEmbed(url: string): string {
-  const id = getYouTubeVideoId(url);
-  if (!id) return url;
-  return `https://www.youtube-nocookie.com/embed/${id}`;
+/**
+ * Build a safe embed URL for a video media item.
+ * Returns null when no video id can be extracted — callers must then fall
+ * back to image rendering, never iframe the raw URL.
+ */
+function getEmbedSrc(item: MediaItem): string | null {
+  if (item.type === "loom") {
+    const id = getLoomVideoId(item.url);
+    return id ? `https://www.loom.com/embed/${id}` : null;
+  }
+  if (item.type === "youtube") {
+    const id = getYouTubeVideoId(item.url);
+    return id ? `https://www.youtube-nocookie.com/embed/${id}` : null;
+  }
+  return null;
 }
 
 interface MediaGalleryProps {
@@ -26,7 +29,7 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
 
   const current = media[active];
   const hasMultiple = media.length > 1;
-  const currentIsVideo = isVideoMedia(current);
+  const currentEmbedSrc = getEmbedSrc(current);
 
   return (
     <div style={{ marginBottom: 28 }}>
@@ -35,16 +38,16 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
         style={{
           position: "relative",
           width: "100%",
-          paddingBottom: currentIsVideo ? "56.25%" : "60%", // 9/16 for video, 3/5 for images
+          paddingBottom: currentEmbedSrc ? "56.25%" : "60%", // 9/16 for video, 3/5 for images
           borderRadius: 12,
           overflow: "hidden",
           background: C.surfaceWarm,
           border: `1px solid ${C.border}`,
         }}
       >
-        {currentIsVideo ? (
+        {currentEmbedSrc ? (
           <iframe
-            src={current.type === "loom" ? toLoomEmbed(current.url) : toYouTubeEmbed(current.url)}
+            src={currentEmbedSrc}
             style={{
               position: "absolute",
               inset: 0,
@@ -184,7 +187,7 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
                 transition: "opacity 0.15s, border-color 0.15s",
               }}
             >
-              {isVideoMedia(item) ? (
+              {getEmbedSrc(item) ? (
                 <div
                   style={{
                     width: "100%",

--- a/components/MediaGallery.tsx
+++ b/components/MediaGallery.tsx
@@ -1,11 +1,18 @@
 import { useState } from "react";
-import { C, T, type MediaItem } from "@/types";
+import { C, T, getYouTubeVideoId, isVideoMedia, type MediaItem } from "@/types";
 
 /** Convert a loom.com/share URL to an embeddable URL */
 function toLoomEmbed(url: string): string {
   const match = url.match(/loom\.com\/(?:share|embed)\/([a-zA-Z0-9]+)/);
   if (!match) return url;
   return `https://www.loom.com/embed/${match[1]}`;
+}
+
+/** Convert a YouTube watch/short URL to a privacy-enhanced embed URL */
+function toYouTubeEmbed(url: string): string {
+  const id = getYouTubeVideoId(url);
+  if (!id) return url;
+  return `https://www.youtube-nocookie.com/embed/${id}`;
 }
 
 interface MediaGalleryProps {
@@ -19,24 +26,25 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
 
   const current = media[active];
   const hasMultiple = media.length > 1;
+  const currentIsVideo = isVideoMedia(current);
 
   return (
     <div style={{ marginBottom: 28 }}>
-      {/* Main display — 5:3 aspect ratio (Product Hunt style) */}
+      {/* Main display — 16:9 for video embeds, 5:3 for images (Product Hunt style) */}
       <div
         style={{
           position: "relative",
           width: "100%",
-          paddingBottom: "60%", // 3/5 = 60% -> 5:3 aspect
+          paddingBottom: currentIsVideo ? "56.25%" : "60%", // 9/16 for video, 3/5 for images
           borderRadius: 12,
           overflow: "hidden",
           background: C.surfaceWarm,
           border: `1px solid ${C.border}`,
         }}
       >
-        {current.type === "loom" ? (
+        {currentIsVideo ? (
           <iframe
-            src={toLoomEmbed(current.url)}
+            src={current.type === "loom" ? toLoomEmbed(current.url) : toYouTubeEmbed(current.url)}
             style={{
               position: "absolute",
               inset: 0,
@@ -44,9 +52,10 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
               height: "100%",
               border: "none",
             }}
+            loading="lazy"
             allowFullScreen
             allow="autoplay; fullscreen; picture-in-picture"
-            title="Loom video"
+            title={current.type === "loom" ? "Loom video" : "YouTube video"}
           />
         ) : (
           <img
@@ -175,7 +184,7 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
                 transition: "opacity 0.15s, border-color 0.15s",
               }}
             >
-              {item.type === "loom" ? (
+              {isVideoMedia(item) ? (
                 <div
                   style={{
                     width: "100%",

--- a/components/MediaUpload.tsx
+++ b/components/MediaUpload.tsx
@@ -4,7 +4,7 @@ import { gxApi } from "@/lib/api";
 
 interface MediaFile {
   url: string;
-  type: "image" | "loom";
+  type: "image" | "loom" | "youtube";
   uploading?: boolean;
   progress?: string;
 }
@@ -158,7 +158,7 @@ export default function MediaUpload({ value, onChange, maxFiles = 5 }: MediaUplo
                   background: "#1a1a2e", color: "#fff",
                   fontSize: T.caption, fontFamily: "var(--sans)", fontWeight: 500,
                 }}>
-                  Loom
+                  {m.type === "loom" ? "Loom" : "Video"}
                 </div>
               )}
               {m.uploading && (

--- a/components/ProjectDetailClient.tsx
+++ b/components/ProjectDetailClient.tsx
@@ -16,6 +16,8 @@ import {
   normalizeThread,
   getCompanyLogoUrl,
   getStackLogoUrl,
+  getBuildathonLabel,
+  formatProjectDate,
   STACK_META,
 } from "@/types";
 import { bxApi } from "@/lib/api";
@@ -696,15 +698,13 @@ export default function ProjectDetailPage() {
                     {p.track && <TrackChip track={p.track} />}
                   </div>
                 )}
-                <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: T.label, color: C.textMute, fontFamily: "var(--sans)", fontWeight: 450 }}>
-                  <span>{p.date}</span>
-                  {p.buildathon && (
-                    <>
-                      <span style={{ opacity: 0.4 }}>{"\u00B7"}</span>
-                      <span>{p.buildathon}</span>
-                    </>
-                  )}
-                </div>
+                {(formatProjectDate(p.date) || p.buildathon) && (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: T.label, color: C.textMute, fontFamily: "var(--sans)", fontWeight: 450, flexWrap: "wrap" }}>
+                    {formatProjectDate(p.date) && <span>{formatProjectDate(p.date)}</span>}
+                    {formatProjectDate(p.date) && p.buildathon && <span style={{ opacity: 0.4 }}>{"\u00B7"}</span>}
+                    {p.buildathon && <span>{getBuildathonLabel(p.buildathon)}</span>}
+                  </div>
+                )}
               </div>
             </div>
             <div ref={voteBtnRef} style={{ flexShrink: 0, display: isMobile ? "none" : "flex", gap: 10, alignItems: "center" }}>

--- a/components/RichTextDisplay.tsx
+++ b/components/RichTextDisplay.tsx
@@ -33,9 +33,28 @@ function renderInline(line: string, lineKey: number): React.ReactNode[] {
       );
     }
     if (/^https?:\/\//.test(part)) {
-      // Keep trailing punctuation out of the link
-      const trailing = part.match(/[),.;:!?]+$/)?.[0] ?? "";
-      const url = trailing ? part.slice(0, part.length - trailing.length) : part;
+      // Keep trailing punctuation out of the link. A trailing ")" stays part
+      // of the URL while it has an unmatched "(" (Wikipedia-style paths).
+      let url = part;
+      let trailing = "";
+      while (url.length > 0) {
+        const ch = url[url.length - 1];
+        if (/[,.;:!?]/.test(ch)) {
+          trailing = ch + trailing;
+          url = url.slice(0, -1);
+          continue;
+        }
+        if (ch === ")") {
+          const opens = (url.match(/\(/g) || []).length;
+          const closes = (url.match(/\)/g) || []).length;
+          if (closes > opens) {
+            trailing = ch + trailing;
+            url = url.slice(0, -1);
+            continue;
+          }
+        }
+        break;
+      }
       return (
         <React.Fragment key={`${lineKey}-${i}`}>
           <a

--- a/components/RichTextDisplay.tsx
+++ b/components/RichTextDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import React from "react";
 import { C } from "@/types";
 import { isLexicalJson } from "@/lib/editor-utils";
 
@@ -16,11 +17,80 @@ interface RichTextDisplayProps {
   description: string;
 }
 
+// ---- Markdown-lite rendering for legacy plain-text descriptions ----
+// Supports **bold**, `---` horizontal rules, and bare http(s) links.
+// Builds React nodes only — never raw HTML (descriptions are builder-authored).
+
+const INLINE_TOKEN = /(\*\*[^*\n]+\*\*|https?:\/\/[^\s]+)/g;
+
+function renderInline(line: string, lineKey: number): React.ReactNode[] {
+  return line.split(INLINE_TOKEN).map((part, i) => {
+    if (/^\*\*[^*\n]+\*\*$/.test(part)) {
+      return (
+        <strong key={`${lineKey}-${i}`} style={{ fontWeight: 600 }}>
+          {part.slice(2, -2)}
+        </strong>
+      );
+    }
+    if (/^https?:\/\//.test(part)) {
+      // Keep trailing punctuation out of the link
+      const trailing = part.match(/[),.;:!?]+$/)?.[0] ?? "";
+      const url = trailing ? part.slice(0, part.length - trailing.length) : part;
+      return (
+        <React.Fragment key={`${lineKey}-${i}`}>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: C.blue,
+              textDecoration: "underline",
+              textUnderlineOffset: 2,
+              overflowWrap: "anywhere",
+            }}
+          >
+            {url}
+          </a>
+          {trailing}
+        </React.Fragment>
+      );
+    }
+    return part;
+  });
+}
+
+function renderMarkdownLite(text: string): React.ReactNode[] {
+  const lines = text.split("\n");
+  return lines.map((line, i) => {
+    if (line.trim() === "---") {
+      return (
+        <hr
+          key={i}
+          style={{
+            border: "none",
+            borderTop: `1px solid ${C.borderLight}`,
+            margin: "16px 0",
+          }}
+        />
+      );
+    }
+    const next = lines[i + 1];
+    const needsNewline = i < lines.length - 1 && (next === undefined || next.trim() !== "---");
+    return (
+      <React.Fragment key={i}>
+        {renderInline(line, i)}
+        {needsNewline ? "\n" : null}
+      </React.Fragment>
+    );
+  });
+}
+
 export default function RichTextDisplay({ description }: RichTextDisplayProps) {
-  // Legacy plain text — render as <p> tag (zero JS overhead, identical to current)
+  // Legacy plain text — render markdown-lite as React nodes (zero editor JS overhead).
+  // A <div> (not <p>) so <hr> rules are valid HTML and SSR hydration stays clean.
   if (!isLexicalJson(description)) {
     return (
-      <p
+      <div
         style={{
           fontSize: 16, lineHeight: 1.7, color: C.text,
           fontFamily: "var(--sans)", fontWeight: 400,
@@ -28,8 +98,8 @@ export default function RichTextDisplay({ description }: RichTextDisplayProps) {
           whiteSpace: "pre-wrap",
         }}
       >
-        {description}
-      </p>
+        {renderMarkdownLite(description)}
+      </div>
     );
   }
 

--- a/lib/editor-utils.ts
+++ b/lib/editor-utils.ts
@@ -82,3 +82,16 @@ export function getEditorState(description: string): string {
 export function descriptionCharCount(description: string): number {
   return extractPlainText(description).length;
 }
+
+/**
+ * Strip markdown-lite markers (**bold**, `---` rule lines) from plain text.
+ * Use for truncated previews and meta descriptions where markers must not show.
+ */
+export function stripMarkdownLite(text: string): string {
+  if (!text) return '';
+  return text
+    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+    .split('\n')
+    .filter(line => line.trim() !== '---')
+    .join('\n');
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -100,7 +100,7 @@ export interface GalleryItem {
 }
 
 export interface MediaItem {
-  type: "image" | "loom";
+  type: "image" | "loom" | "youtube";
   url: string;
 }
 
@@ -306,6 +306,26 @@ function isLoomUrl(url: string): boolean {
   return /^https?:\/\/(www\.)?loom\.com\/(share|embed)\//.test(url);
 }
 
+/** Extract a YouTube video id from watch / youtu.be / embed / shorts URLs (null if not YouTube) */
+export function getYouTubeVideoId(url: string): string | null {
+  const m = url.match(
+    /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?[^#]*?v=|embed\/|shorts\/)|youtu\.be\/)([A-Za-z0-9_-]{6,})/
+  );
+  return m ? m[1] : null;
+}
+
+/** Classify a media URL as loom, youtube, or image */
+export function detectMediaType(url: string): MediaItem["type"] {
+  if (isLoomUrl(url)) return "loom";
+  if (getYouTubeVideoId(url)) return "youtube";
+  return "image";
+}
+
+/** True if a media item is a video embed (not an image) */
+export function isVideoMedia(item: MediaItem): boolean {
+  return item.type === "loom" || item.type === "youtube";
+}
+
 /** Parse raw media array (strings or objects) into typed MediaItem[] */
 function normalizeMedia(raw: unknown): MediaItem[] {
   if (!Array.isArray(raw)) return [];
@@ -314,18 +334,42 @@ function normalizeMedia(raw: unknown): MediaItem[] {
       if (typeof item === "string") {
         const url = item.trim();
         if (!url) return null;
-        return { type: isLoomUrl(url) ? "loom" : "image", url } as MediaItem;
+        return { type: detectMediaType(url), url } as MediaItem;
       }
       if (item && typeof item === "object") {
         const obj = item as Record<string, unknown>;
         const url = ((obj.url ?? "") as string).trim();
         if (!url) return null;
-        const type = obj.type === "loom" || isLoomUrl(url) ? "loom" : "image";
+        const type = obj.type === "loom" || obj.type === "youtube" ? obj.type : detectMediaType(url);
         return { type, url } as MediaItem;
       }
       return null;
     })
     .filter(Boolean) as MediaItem[];
+}
+
+// ---- Buildathon display labels ----
+
+/** Map of raw buildathon tags to human-readable display labels. Unknown tags fall back to the raw value. */
+export const BUILDATHON_LABELS: Record<string, string> = {
+  sarvam: "Sarvam Epoch Buildathon by GrowthX",
+  opencode: "OpenCode Buildathon",
+  "ai-weekender": "AI Weekender Buildathon",
+};
+
+export function getBuildathonLabel(tag: string): string {
+  return BUILDATHON_LABELS[tag] ?? tag;
+}
+
+/**
+ * Format a project date for display (e.g. "26 Jul 2026").
+ * Returns "" when the value doesn't parse as a date so callers can hide it.
+ */
+export function formatProjectDate(raw: string): string {
+  if (!raw) return "";
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
 }
 
 /** Normalize a backend project (with populated creator/collabs) to frontend Project shape */

--- a/types/index.ts
+++ b/types/index.ts
@@ -301,22 +301,24 @@ function normalizeReactions(raw: unknown[]): Reaction[] {
   });
 }
 
-/** Detect if a URL is a Loom video */
-function isLoomUrl(url: string): boolean {
-  return /^https?:\/\/(www\.)?loom\.com\/(share|embed)\//.test(url);
-}
-
 /** Extract a YouTube video id from watch / youtu.be / embed / shorts URLs (null if not YouTube) */
 export function getYouTubeVideoId(url: string): string | null {
   const m = url.match(
-    /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?[^#]*?v=|embed\/|shorts\/)|youtu\.be\/)([A-Za-z0-9_-]{6,})/
+    /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?(?:[^#]*&)?v=|embed\/|shorts\/)|youtu\.be\/)([A-Za-z0-9_-]{6,})/
   );
   return m ? m[1] : null;
 }
 
-/** Classify a media URL as loom, youtube, or image */
+/** Extract a Loom video id from share/embed URLs (null if not Loom) */
+export function getLoomVideoId(url: string): string | null {
+  const m = url.match(/^https?:\/\/(?:www\.)?loom\.com\/(?:share|embed)\/([a-zA-Z0-9]+)/);
+  return m ? m[1] : null;
+}
+
+/** Classify a media URL as loom, youtube, or image. Only classifies as video
+ * when a video id is actually extractable, so consumers can safely embed. */
 export function detectMediaType(url: string): MediaItem["type"] {
-  if (isLoomUrl(url)) return "loom";
+  if (getLoomVideoId(url)) return "loom";
   if (getYouTubeVideoId(url)) return "youtube";
   return "image";
 }
@@ -340,8 +342,9 @@ function normalizeMedia(raw: unknown): MediaItem[] {
         const obj = item as Record<string, unknown>;
         const url = ((obj.url ?? "") as string).trim();
         if (!url) return null;
-        const type = obj.type === "loom" || obj.type === "youtube" ? obj.type : detectMediaType(url);
-        return { type, url } as MediaItem;
+        // Never trust a claimed type — re-derive from the URL so a mislabeled
+        // entry can't reach an <iframe src> without a valid video id.
+        return { type: detectMediaType(url), url } as MediaItem;
       }
       return null;
     })


### PR DESCRIPTION
## Summary

Four fixes for the Sarvam Epoch Buildathon detail pages (apply to all buildathons):

- **Description markdown rendering** — plain-text descriptions now render markdown-lite: `**bold**` as bold, a line that is exactly `---` as a subtle horizontal rule, and bare http(s) URLs as clickable links (`target="_blank" rel="noopener noreferrer"`, trailing punctuation kept out of the href). Built entirely as React nodes — no `dangerouslySetInnerHTML`, no new dependency. The plain-text container moved from `<p>` to `<div>` so `<hr>` stays valid HTML for SSR hydration. Meta description, og:description, and JSON-LD on the detail route strip the markers via `stripMarkdownLite(extractPlainText(...))`.
- **Video embeds in media** — `media[]` entries that are YouTube URLs (`watch?v=`, `youtu.be/`, `embed/`, `shorts/`) render as `youtube-nocookie.com/embed/<id>` iframes; Loom keeps its existing embed. Video embeds use a 16:9 frame (images stay 5:3) and iframes are lazy-loaded. `MediaItem.type` widened to `"image" | "loom" | "youtube"`; the edit form (`my-projects`) and `MediaUpload` thumbnails are guarded so a video URL never lands in an `<img src>`. Cards/og:image never read `media[]` (og:image uses `project.icon`), so no other consumers needed guarding. A media section with only a video renders fine.
- **Date formatting** — `p.date` (raw `created_at` ISO string) now renders via `formatProjectDate()` as e.g. `28 Jul 2026`; unparseable values hide the date instead of printing garbage, and the separator dot only shows when both date and buildathon exist.
- **Buildathon labels** — new `BUILDATHON_LABELS` map: `sarvam` → "Sarvam Epoch Buildathon by GrowthX", `opencode` → "OpenCode Buildathon", `ai-weekender` → "AI Weekender Buildathon", unknown tags fall back to the raw value.

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` error list byte-identical to the origin/main baseline (8 pre-existing errors in dead Next-era files)
- [x] Verified visually in dev mock mode (temporary local seed tweak, not committed): bold/hr/link rendering in the description footer, Loom + YouTube tiles in the gallery, YouTube-nocookie embed playing at 16:9, meta line showing `28 Jul 2026 · Sarvam Epoch Buildathon by GrowthX`
- [x] Regex helpers sanity-checked (YouTube id extraction across URL shapes, non-YouTube URLs return null, invalid dates hidden, marker stripping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvHQy8eieamvpaeqtHfT9A