### PR TITLE
feat(home): hide sarvam batch from the home feed

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -219,6 +219,7 @@ export default function HomePage() {
           headerTitle="What the community shipped"
           headerSubtitle="Products built by the GrowthX community. Ranked by the people who build."
           refreshKey={listRefreshKey}
+          excludeBuildathon="sarvam"
         />
       </main>
 

--- a/components/ProjectListView.tsx
+++ b/components/ProjectListView.tsx
@@ -121,6 +121,13 @@ export interface ProjectListViewProps {
   headerSubtitle: string;
   /** Optional buildathon tag (e.g. 'ai-weekender') passed as ?buildathon= filter */
   buildathonFilter?: string;
+  /**
+   * Optional buildathon tag to EXCLUDE (passed as ?exclude_buildathon=).
+   * Ignored when buildathonFilter is set — the backend applies the same
+   * precedence. Used to keep a freshly backfilled batch off the home feed
+   * while its dedicated route stays live.
+   */
+  excludeBuildathon?: string;
   /** Custom empty-state content shown when API returns no projects */
   emptyState?: {
     icon?: string;
@@ -176,6 +183,7 @@ export default function ProjectListView({
   headerTitle,
   headerSubtitle,
   buildathonFilter,
+  excludeBuildathon,
   emptyState,
   defaultSort = "trending",
   refreshKey = 0,
@@ -201,7 +209,11 @@ export default function ProjectListView({
   sortModeRef.current = sortMode;
   const usingCustomFilters = !!customFilters && customFilters.length > 0;
 
-  const filterSuffix = buildathonFilter ? `&buildathon=${encodeURIComponent(buildathonFilter)}` : "";
+  const filterSuffix = buildathonFilter
+    ? `&buildathon=${encodeURIComponent(buildathonFilter)}`
+    : excludeBuildathon
+      ? `&exclude_buildathon=${encodeURIComponent(excludeBuildathon)}`
+      : "";
 
   const loadProjects = useCallback(() => {
     const requestedSort = sortMode;


### PR DESCRIPTION
## Summary
- `ProjectListView` gains `excludeBuildathon` prop → `&exclude_buildathon=` query param (ignored when `buildathonFilter` set, same precedence as backend).
- Home route (`/`) passes `excludeBuildathon="sarvam"`. /projects redirects to /, so home is the only surface. /sarvam, builder-profile project lists, and event-card counts unchanged.
- MERGE ORDER: after gx-backend exclude_buildathon PR is deployed (older backend Joi 400s on unknown query params).

## Test plan
- `npm run build` passes.
- Verified /sarvam still passes `buildathon=sarvam` (exact-match path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvHQy8eieamvpaeqtHfT9A