### PR TITLE
feat(home): hide sarvam launches from the activity sidebar

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -227,7 +227,7 @@ export default function HomePage() {
       {!isMobile && !isTablet && (
         <aside style={{ width: 280, flexShrink: 0 }}>
           <div style={{ paddingTop: 32 }}>
-            <ActivityFeed />
+            <ActivityFeed excludeBuildathon="sarvam" />
           </div>
         </aside>
       )}

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -38,14 +38,15 @@ function activityText(item: ActivityItem): string {
   }
 }
 
-export default function ActivityFeed() {
+export default function ActivityFeed({ excludeBuildathon }: { excludeBuildathon?: string } = {}) {
   const router = useRouter();
   const [items, setItems] = useState<ActivityItem[]>([]);
   const [available, setAvailable] = useState(true);
   const [loading, setLoading] = useState(true);
 
   const fetchActivity = useCallback(() => {
-    bxApi("/activity")
+    const suffix = excludeBuildathon ? `?exclude_buildathon=${encodeURIComponent(excludeBuildathon)}` : "";
+    bxApi(`/activity${suffix}`)
       .then(r => {
         if (!r.ok) { if (r.status === 404) setAvailable(false); return null; }
         return r.json();
@@ -53,7 +54,7 @@ export default function ActivityFeed() {
       .then(d => { if (d) setItems(d.activity || d.items || []); })
       .catch(() => setAvailable(false))
       .finally(() => setLoading(false));
-  }, []);
+  }, [excludeBuildathon]);
 
   useEffect(() => {
     fetchActivity();


### PR DESCRIPTION
## Summary
- `ActivityFeed` gains optional `excludeBuildathon` prop → `?exclude_buildathon=` on `/activity`; home passes `sarvam`.
- MERGE ORDER: after gx-backend #3547 deploys (Joi on the current prod /activity 400s unknown query params, and the component treats a non-ok response as feed-unavailable — sidebar would vanish).

## Test plan
- `npm run build` passes.
- Other ActivityFeed consumers: none (home only, verified by grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvHQy8eieamvpaeqtHfT9A