### PR TITLE
feat(home): time-boxed Sarvam showcase banner

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { useLoginDialog } from "@/context/LoginDialogContext";
 import { useResponsive } from "@/hooks/useMediaQuery";
 import RichTextEditor from "@/components/RichTextEditor";
 import ActivityFeed from "@/components/ActivityFeed";
+import SarvamBanner from "@/components/SarvamBanner";
 import ProjectListView from "@/components/ProjectListView";
 import { descriptionCharCount } from "@/lib/editor-utils";
 import MediaUpload from "@/components/MediaUpload";
@@ -215,6 +216,7 @@ export default function HomePage() {
         padding: isMobile ? "0" : isTablet ? "0" : "0 32px",
       }}>
       <main className="responsive-main" style={{ flex: 1, maxWidth: 960, padding: isMobile ? "20px 16px 80px" : isTablet ? "32px 32px 100px" : "32px 0 100px" }}>
+        <SarvamBanner isMobile={isMobile} />
         <ProjectListView
           headerTitle="What the community shipped"
           headerSubtitle="Products built by the GrowthX community. Ranked by the people who build."

--- a/components/SarvamBanner.tsx
+++ b/components/SarvamBanner.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+import { C } from "@/types";
+
+// Home-page banner for the Sarvam Epoch Buildathon showcase. Time-boxed:
+// renders only until BANNER_EXPIRES (7 days from launch, IST), after which it
+// disappears without a deploy. Dismissable per-browser via localStorage.
+const BANNER_EXPIRES = new Date("2026-08-05T23:59:59+05:30");
+const DISMISS_KEY = "bx_sarvam_banner_dismissed";
+
+export default function SarvamBanner({ isMobile }: { isMobile?: boolean }) {
+  // Start hidden on both server and client so SSR + hydration match; the
+  // mount effect reveals it (or not) based on the expiry and the dismissal.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (new Date() > BANNER_EXPIRES) return;
+    try {
+      if (localStorage.getItem(DISMISS_KEY) === "1") return;
+    } catch {
+      /* storage unavailable — show anyway */
+    }
+    setVisible(true);
+  }, []);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      /* private mode — banner just returns next visit */
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        flexWrap: "wrap",
+        background: C.goldSoft,
+        border: `1px solid ${C.goldBorder}`,
+        borderRadius: 12,
+        padding: isMobile ? "14px 40px 14px 16px" : "16px 48px 16px 20px",
+        marginBottom: 24,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 220 }}>
+        <div
+          style={{
+            fontFamily: "var(--serif)",
+            fontSize: isMobile ? 17 : 19,
+            color: C.text,
+            marginBottom: 2,
+          }}
+        >
+          Sarvam Epoch Buildathon by GrowthX
+        </div>
+        <div style={{ fontSize: 13.5, color: C.textMute, lineHeight: 1.45 }}>
+          ~600 builders, one day, shipping with Sarvam AI — the projects are in.
+        </div>
+      </div>
+      <Link
+        to="/sarvam"
+        style={{
+          fontSize: 13.5,
+          fontWeight: 600,
+          color: C.gold,
+          textDecoration: "none",
+          whiteSpace: "nowrap",
+        }}
+      >
+        See the projects →
+      </Link>
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss banner"
+        style={{
+          position: "absolute",
+          top: 8,
+          right: 8,
+          width: 28,
+          height: 28,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "transparent",
+          border: "none",
+          borderRadius: 8,
+          color: C.textMute,
+          cursor: "pointer",
+          fontSize: 16,
+          lineHeight: 1,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `components/SarvamBanner.tsx` rendered above the home ProjectListView: gold (goldSoft/goldBorder) callout, serif title "Sarvam Epoch Buildathon by GrowthX", one-line sub, "See the projects →" linking to /sarvam.
- Time-boxed: hidden after 2026-08-05 23:59 IST (7 days) with no deploy needed; dismissible via localStorage (`bx_sarvam_banner_dismissed`).
- SSR-safe: initial state false on server AND client, revealed in a mount effect — no hydration mismatch.

## Test plan
- `npm run build` passes; typecheck error list byte-identical to origin/main baseline.
- Light + dark tokens used (goldSoft/goldBorder have dark variants in globals.css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvHQy8eieamvpaeqtHfT9A