### PR TITLE
copy(sarvam): subtitle to partner credit only

### DIFF
--- a/app/routes/sarvam.tsx
+++ b/app/routes/sarvam.tsx
@@ -40,7 +40,7 @@ export default function SarvamPage() {
         <main className="responsive-main" style={{ padding: isMobile ? "20px 16px 80px" : isTablet ? "32px 32px 100px" : "32px 0 100px" }}>
           <ProjectListView
             headerTitle="Sarvam Epoch Buildathon by GrowthX"
-            headerSubtitle="One-day buildathon on 26 July 2026 — ~600 builders shipping with Sarvam AI. Powered by Lightspeed, Bessemer & Supported by Razorpay."
+            headerSubtitle="Powered by Lightspeed, Bessemer & Supported by Razorpay."
             buildathonFilter="sarvam"
             featuredEnabled={false}
             emptyState={{


### PR DESCRIPTION
## Summary
Visible /sarvam subtitle becomes exactly: "Powered by Lightspeed, Bessemer & Supported by Razorpay." (Udayan-dictated). Meta/og descriptions unchanged — they keep the fuller date/builders context for SEO and link previews.

## Test plan
- `npm run build` passes; string-literal-only diff in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvHQy8eieamvpaeqtHfT9A