### PR TITLE
copy(builders): ranking copy to shipped-first

### DIFF
--- a/app/routes/builders.tsx
+++ b/app/routes/builders.tsx
@@ -16,13 +16,13 @@ import { useResponsive } from "@/hooks/useMediaQuery";
 
 export const meta: MetaFunction = () => [
   { title: "Top Builders — Built at GrowthX" },
-  { name: "description", content: "Leaderboard of top builders in the GrowthX community, ranked by reputation and projects shipped." },
+  { name: "description", content: "Leaderboard of top builders in the GrowthX community, ranked by projects shipped." },
   { property: "og:title", content: "Top Builders — Built at GrowthX" },
-  { property: "og:description", content: "Leaderboard of top builders in the GrowthX community, ranked by reputation and projects shipped." },
+  { property: "og:description", content: "Leaderboard of top builders in the GrowthX community, ranked by projects shipped." },
   { property: "og:type", content: "website" },
   { name: "twitter:card", content: "summary" },
   { name: "twitter:title", content: "Top Builders — Built at GrowthX" },
-  { name: "twitter:description", content: "Leaderboard of top builders in the GrowthX community, ranked by reputation and projects shipped." },
+  { name: "twitter:description", content: "Leaderboard of top builders in the GrowthX community, ranked by projects shipped." },
   { tagName: "link", rel: "canonical", href: "https://built.growthx.club/builders" },
 ];
 
@@ -148,7 +148,7 @@ export default function BuildersPage() {
             The people who build
           </h1>
           <p style={{ fontSize: T.bodyLg, color: C.textSec, fontFamily: "var(--sans)", fontWeight: 400, maxWidth: 560 }}>
-            Reputation is earned by shipping. Ranked by cumulative score across projects, buildathons, and collaborations.
+            Reputation is earned by shipping. Ranked by projects shipped across buildathons and collaborations, with community upvotes breaking ties.
           </p>
         </div>
 

--- a/app/routes/llms[.]txt.ts
+++ b/app/routes/llms[.]txt.ts
@@ -10,7 +10,7 @@ Built at GrowthX is where members of GrowthX share, vote on, and discuss the pro
 ## Sections
 
 - [Projects](https://built.growthx.club/projects) — Browse all shipped projects, sorted by votes or recency
-- [Builders](https://built.growthx.club/builders) — Leaderboard of top builders ranked by reputation and projects shipped
+- [Builders](https://built.growthx.club/builders) — Leaderboard of top builders ranked by projects shipped, with community upvotes breaking ties
 - [Building](https://built.growthx.club/building) — Projects currently in progress (ideas, prototyping, beta)
 - [Cities](https://built.growthx.club/cities) — City-wise breakdown of builders and projects shipped across India
 


### PR DESCRIPTION
## Summary
- gx-backend#3559 (merged) changed the /bx/members leaderboard sort to shipped desc with upvote rep as tiebreak. This updates the /builders page subtitle and meta/og/twitter descriptions so the copy describes the actual ranking.

## Test plan
- Copy-only change (4 strings in `app/routes/builders.tsx`), no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CgaDaN4WVjZwEkobbnFr5