### PR TITLE
feat(home): unhide Sarvam projects from home feed and activity sidebar

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -221,7 +221,6 @@ export default function HomePage() {
           headerTitle="What the community shipped"
           headerSubtitle="Products built by the GrowthX community. Ranked by the people who build."
           refreshKey={listRefreshKey}
-          excludeBuildathon="sarvam"
         />
       </main>
 
@@ -229,7 +228,7 @@ export default function HomePage() {
       {!isMobile && !isTablet && (
         <aside style={{ width: 280, flexShrink: 0 }}>
           <div style={{ paddingTop: 32 }}>
-            <ActivityFeed excludeBuildathon="sarvam" />
+            <ActivityFeed />
           </div>
         </aside>
       )}


### PR DESCRIPTION
## Summary
- Removes the temporary `excludeBuildathon="sarvam"` props from `ProjectListView` and `ActivityFeed` in `app/routes/_index.tsx` (added in #80/#81 while the Sarvam showcase was in prep).
- Sarvam buildathon projects (218) now appear on the built.growthx.club home feed and in the activity sidebar, alongside the rest of the catalog.
- Backend `exclude_buildathon` param support (gx-backend #3544/#3547) is untouched — the FE simply stops passing it.

## Test plan
- Both components declare `excludeBuildathon` as optional; with the prop absent no `exclude_buildathon` query param is sent, which is the pre-hide behavior.
- Verify on the Vercel preview: home feed shows Sarvam projects (tagged buildathon=sarvam) mixed into the list; activity sidebar includes Sarvam activity.
- After merge: spot-check https://built.growthx.club home feed for Sarvam projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmx1wAnrXPkVyZZh5Zj94